### PR TITLE
Fix NA handling cleanup.import with charfactor

### DIFF
--- a/R/upData.s
+++ b/R/upData.s
@@ -146,7 +146,7 @@ cleanup.import <-
       if(charfactor && is.character(x)) {
         if(length(unique(x)) < .5*length(x)) {
           x <- sub(' +$', '', x)  # remove trailing blanks
-          x <- factor(x, exclude='')
+          x <- factor(x, exclude=c('', NA))
           modif <- TRUE
         }
       }


### PR DESCRIPTION
NA's appear to be handled incorrectly cleanup.import when called with charfactor, creating a NA level in the new factor if the underlying character vector has NAs.  This creates unexpected behavior in the resulting factors. Example:

``` r
dx <- data.frame(x = c("A", NA, NA, "B", "A", "A", "B"), stringsAsFactors = FALSE)
cx <- cleanup.import(dx, charfactor = TRUE)
levels(cx$x)
table(cx$x)  # should need option useNA to display the NA's
```

New behavior adds NA to the exclude.
